### PR TITLE
Resolve circular import problem

### DIFF
--- a/lua/coverage/languages/java.lua
+++ b/lua/coverage/languages/java.lua
@@ -3,7 +3,6 @@ local M = {}
 local Path = require "plenary.path"
 local config = require "coverage.config"
 local util = require "coverage.util"
-local cs = require "coverage.signs"
 local lom = require "neotest.lib.xml"
 
 --- Loads a coverage report.
@@ -140,6 +139,7 @@ end
 -- return a list of signs.
 -- @return list of signs
 M.sign_list = function(data)
+    local cs = require "coverage.signs"
     local signs = {}
     local funcs = {
         covered = cs.new_covered,


### PR DESCRIPTION
This would fail the pcall in lua/coverage/init.lua:40, causing a "Coverage report not available for filetype java" error message.

Figured this out by running `:lua require "coverage.languages.java"`

I'm not exactly sure where the cycle actually happens, but this fixed it for me (notably, only in this branch) and might fix @BasBouwhuis-sf's problem [here](https://github.com/andythigpen/nvim-coverage/pull/51#issuecomment-2340287603)